### PR TITLE
feat: import components on doc template

### DIFF
--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -14,9 +14,6 @@ exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
     resolve: {
       modules: [path.resolve(__dirname, 'src'), 'node_modules'],
-      alias: {
-        components: path.resolve(__dirname, 'src/components'),
-      },
     },
   });
 };

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -2,12 +2,19 @@ import React from "react"
 import { graphql } from "gatsby"
 
 import MDXRenderer from 'gatsby-mdx/mdx-renderer';
+import { MDXProvider } from '@mdx-js/react'
 
 // import SiteInfo from "../components/siteInfo"
 import Layout from "../components/layout"
 // import SEO from "../components/seo"
 // import { rhythm, scale } from "../utils/typography"
 
+import Callout from "../components/callout";
+import Alert from "../components/alert";
+import Accordion from "../components/accordion"
+import ExternalLink from "../components/externalLink"
+
+const shortcodes = { Callout, Alert, Accordion, ExternalLink }
 
 class DocTemplate extends React.Component {
   render() {
@@ -21,7 +28,9 @@ class DocTemplate extends React.Component {
             <p className="article-subhead">
               {node.frontmatter.description}
             </p>
-            <MDXRenderer>{node.code.body}</MDXRenderer>
+            <MDXProvider components={shortcodes}>
+              <MDXRenderer>{node.code.body}</MDXRenderer>
+            </MDXProvider>
           </div>
         </div>
       </Layout>


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- import components globally at `gatsby/src/templates/doc.js` template file
- remove webpack alias configuration

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
