### PR TITLE
fix: add icon to gatsby-remark-external-links

### DIFF
--- a/gatsby/gatsby-browser.js
+++ b/gatsby/gatsby-browser.js
@@ -7,3 +7,5 @@ require("prismjs/themes/prism-okaidia.css")
 // // TOC generator
 require("tocbot/dist/tocbot.css")
 require("tocbot/dist/tocbot.min.js")
+
+require('./src/styles/global.css')

--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -66,7 +66,7 @@ module.exports = {
             resolve: "gatsby-remark-external-links",
             options: {
               target: "_blank",
-              rel: "nofollow"
+              rel: "nofollow noopener noreferrer external",
             }
           },
         ],

--- a/gatsby/src/components/externalLink.js
+++ b/gatsby/src/components/externalLink.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ExternalLink = ({ text, link }) => {
   return (
-    <a target="_blank" rel="noopener noreferrer" href={link} title="" className="external">{text}</a>
+    <a target="_blank" rel="nofollow noopener noreferrer external" href={link} title={text} className="external">{text}</a>
   );
 };
 

--- a/gatsby/src/styles/global.css
+++ b/gatsby/src/styles/global.css
@@ -1,0 +1,9 @@
+
+a[rel~="external"]:after {
+  content: "\E390";
+  font-family: 'Glyphicons Regular';
+  top: 2px;
+  position: relative;
+  margin-left: 2px;
+  text-decoration: none;
+}

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -182,7 +182,7 @@ terminus connection:set <site>.<env> git
 </Alert>
 
 1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
-2. Add the [Redis](https://www.drupal.org/project/redis){.external} module from Drupal.org. You can install and enable the module from the command line using [Terminus](/docs/terminus):
+2. Add the [Redis](https://www.drupal.org/project/redis) module from Drupal.org. You can install and enable the module from the command line using [Terminus](/docs/terminus):
 
     ```bash
     terminus remote:drush <site>.<env> -- en redis -y


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- add icon to gatsby-remark-external-links
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
