### PR TITLE
fix: show toc on terminuspage

### DIFF
--- a/gatsby/src/components/toc.js
+++ b/gatsby/src/components/toc.js
@@ -9,7 +9,7 @@ const TOC = ({ title }) => {
 
       const settings = {
         tocSelector: ".toc-placeholder",
-        contentSelector: "#doc",
+        contentSelector: ".doc, .terminus",
         orderedList: false,
         headingSelector: "h2, h3",
         ignoreSelector: ".panel-title",

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -53,7 +53,7 @@ class DocTemplate extends React.Component {
       <Layout>
         <div className="container">
           <div className="row doc-content-well">
-            <div id="doc" className="article col-md-9 md-70">
+            <div id="doc" className="doc article col-md-9 md-70">
               <h1>{node.frontmatter.title}</h1>
               <p className="article-subhead">{node.frontmatter.description}</p>
               <Contributors contributors={node.frontmatter.contributors} />

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -113,9 +113,9 @@ class TerminusTemplate extends React.Component {
           <div className="row">
             <div className="row col-md-12 guide-nav manual-guide-toc-well">
               <Navbar title={node.frontmatter.title} items={items} />
-              <div id="terminus" className="col-md-9 guide-doc-body">
+              <div id="terminus" className="terminus col-md-9 guide-doc-body">
                 <div className="row guide-content-well">
-                  <div className="col-xs-12 col-md-12">
+                  <div className="col-xs-9 col-md-9">
                     <header>
                       <h1>{node.frontmatter.subtitle}</h1>
                       <Contributors
@@ -170,6 +170,7 @@ export const pageQuery = graphql`
         description
         nexturl
         previousurl
+        terminustoc
         contributors {
           id
           name


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- show toc on terminuspage
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
