### PR TITLE
fix: show toc dynamically

### DIFF
--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -106,6 +106,8 @@ class TerminusTemplate extends React.Component {
 
   render() {
     const node = this.props.data.mdx
+    // const showToc = node.frontmatter.showToc
+    const contentCols = node.frontmatter.showToc ? 9 : 12
 
     return (
       <Layout>
@@ -115,7 +117,9 @@ class TerminusTemplate extends React.Component {
               <Navbar title={node.frontmatter.title} items={items} />
               <div id="terminus" className="terminus col-md-9 guide-doc-body">
                 <div className="row guide-content-well">
-                  <div className="col-xs-9 col-md-9">
+                  <div
+                    className={`col-xs-${contentCols} col-md-${contentCols}`}
+                  >
                     <header>
                       <h1>{node.frontmatter.subtitle}</h1>
                       <Contributors
@@ -136,12 +140,14 @@ class TerminusTemplate extends React.Component {
                       <MDXRenderer>{node.code.body}</MDXRenderer>
                     </MDXProvider>
                   </div>
-                  <div
-                    className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
-                    role="complementary"
-                  >
-                    <TOC title="Contents" />
-                  </div>
+                  {node.frontmatter.showToc && (
+                    <div
+                      className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
+                      role="complementary"
+                    >
+                      <TOC title="Contents" />
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -170,7 +176,7 @@ export const pageQuery = graphql`
         description
         nexturl
         previousurl
-        terminustoc
+        showToc: terminustoc
         contributors {
           id
           name

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -106,7 +106,6 @@ class TerminusTemplate extends React.Component {
 
   render() {
     const node = this.props.data.mdx
-    // const showToc = node.frontmatter.showToc
     const contentCols = node.frontmatter.showToc ? 9 : 12
 
     return (


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- show toc dynamically
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
