### PR TITLE
refactor: getFeedback, marketoForm and previousNextControl conponents

### DIFF
--- a/gatsby/src/components/getFeedback.js
+++ b/gatsby/src/components/getFeedback.js
@@ -1,12 +1,12 @@
 import React from "react"
 
-const GetFeedBack = () => {
+const GetFeedBack = ({ formId, page, topic }) => {
   return (
     <iframe
       title="GetFeedBack"
       style={{ width: "100%", minHeight: "300px" }}
       frameBorder="0"
-      src={`https://www.getfeedback.com/r/12z1fMzn?page=/docs/redis/&topic=addons`}
+      src={`https://www.getfeedback.com/r/${formId}?page=${page}&topic=${topic}`}
     />
   )
 }

--- a/gatsby/src/components/marketoForm.js
+++ b/gatsby/src/components/marketoForm.js
@@ -37,9 +37,7 @@ const MarketoForm = ({ baseUrl, munchkinId, formId, formName }) => {
 
           setInitialized(true)
         })
-        .catch(() =>
-          console.log("Some error ocurred loading Marketo scripts...")
-        )
+        .catch(() => console.log("An error ocurred loading Marketo scripts..."))
     }
   })
 

--- a/gatsby/src/components/navButtons.js
+++ b/gatsby/src/components/navButtons.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link } from "gatsby"
-const PreviousNextControl = ({ prev, next }) => {
+
+const NavButtons = ({ prev, next }) => {
   return (
     <div className="row terminus-pager col-md-12">
       <div className="col-xs-6 col-md-6">
@@ -29,4 +30,4 @@ const PreviousNextControl = ({ prev, next }) => {
   )
 }
 
-export default PreviousNextControl
+export default NavButtons

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -1,13 +1,9 @@
 import React from "react"
 import { graphql } from "gatsby"
-
 import MDXRenderer from "gatsby-mdx/mdx-renderer"
 import { MDXProvider } from "@mdx-js/react"
 
 import Layout from "../components/layout"
-// import SiteInfo from "../components/siteInfo"
-// import SEO from "../components/seo"
-
 import Callout from "../components/callout"
 import Alert from "../components/alert"
 import Accordion from "../components/accordion"
@@ -91,7 +87,7 @@ class DocTemplate extends React.Component {
             </div>
           </div>
         </div>
-        <GetFeedback />
+        <GetFeedback formId="12z1fMzn" page="/docs/redis/" topic="addons" />
       </Layout>
     )
   }

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -1,13 +1,9 @@
 import React from "react"
 import { graphql } from "gatsby"
-
 import MDXRenderer from "gatsby-mdx/mdx-renderer"
 import { MDXProvider } from "@mdx-js/react"
 
 import Layout from "../components/layout"
-// import SiteInfo from "../components/siteInfo"
-// import SEO from "../components/seo"
-
 import Callout from "../components/callout"
 import Alert from "../components/alert"
 import Accordion from "../components/accordion"
@@ -24,7 +20,7 @@ import Slack from "../components/slack"
 import Card from "../components/card"
 import CardGroup from "../components/cardGroup"
 import Navbar from "../components/navbar"
-import PreviousNextControl from "../components/previousNextControl"
+import NavButtons from "../components/navButtons"
 import SEO from "../components/seo"
 
 const shortcodes = {
@@ -160,7 +156,7 @@ class TerminusTemplate extends React.Component {
                     </div>
                   )}
                 </div>
-                <PreviousNextControl
+                <NavButtons
                   prev={node.frontmatter.previousurl}
                   next={node.frontmatter.nexturl}
                 />


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- getFeedback
- marketoForm
- previousNextControl => navButtons

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
