### PR TITLE
fix: css content before

### DIFF
--- a/gatsby/src/styles/overrides.css
+++ b/gatsby/src/styles/overrides.css
@@ -15,7 +15,7 @@
 #doc h6::before,
 #terminus h6::before {
   display: block;
-  content: none;
+  content: "";
   height: 160px;
   margin-top: -160px;
   visibility: hidden;


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix: css content before
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
